### PR TITLE
Package watcher requires SDK version >=2.0.0-dev.20.0 but the current SDK is 2.0.0-dev.16.0.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ description: >
   A file system watcher. It monitors changes to contents of directories and
   sends notifications when files have been added, removed, or modified.
 environment:
-  sdk: '>=2.0.0-dev.20.0 <2.0.0'
+  sdk: '>=2.0.0-dev.16.0 <2.0.0'
 dependencies:
   async: '>=1.10.0 <3.0.0'
   path: '>=0.9.0 <2.0.0'


### PR DESCRIPTION
Building this project with >=2.0.0-dev.20.0 throws error:
`Package watcher requires SDK version >=2.0.0-dev.20.0 but the current SDK is 2.0.0-dev.16.0.`

This fixes the issue.